### PR TITLE
Align package license metadata with LICENSE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "livewallpaper",
       "version": "1.6.4",
-      "license": "ISC",
+      "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.10.1",
         "@types/three": "^0.181.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "description": "",
   "devDependencies": {
     "@types/node": "^24.10.1",


### PR DESCRIPTION
## Summary

- update the root `package.json` license from `ISC` to `MIT`
- update the root package entry in `package-lock.json` to match

## Why

The repository's checked-in `LICENSE` file is the MIT License, but the npm package metadata currently reports `ISC`. Aligning these keeps package consumers and license scanners consistent with the source license file.

## Verification

- `git diff --check`
- `npm ci`
- `npm run build`